### PR TITLE
Add a fixture to populate some data

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,6 +12,7 @@ ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait
 COPY files/local_settings.py /etc/patchman/local_settings.py
 COPY files/requirements.txt /requirements.txt
 COPY files/run.sh /run.sh
+COPY files/fixtures.json /fixtures.json
 
 # hadolint ignore=DL3018
 RUN apt-get update \

--- a/files/fixtures.json
+++ b/files/fixtures.json
@@ -1,0 +1,1 @@
+[{"model": "sites.site", "pk": 1, "fields": {"domain": "testbed.osism.xyz", "name": "testbed.osism.xyz"}},{"model": "operatingsystems.osgroup", "pk": 1, "fields": {"name": "Ubuntu 20.04", "repos": []}}, {"model": "operatingsystems.os", "pk": 1, "fields": {"name": "Ubuntu 20.04.3 LTS", "osgroup": 1}}]

--- a/files/run.sh
+++ b/files/run.sh
@@ -17,6 +17,7 @@ PATCHMAN_PORT=${PATCHMAN_PORT:-8000}
 patchman-manage collectstatic --noinput
 patchman-manage makemigrations
 patchman-manage migrate --run-syncdb
+patchman-manage loaddata /fixtures.json
 
 result=$(echo "from django.contrib.auth import get_user_model; User = get_user_model(); print(User.objects.filter(username='$PATCHMAN_USERNAME').count()>0)" | patchman-manage shell | tail -n 1)
 if [[ $result == "False" ]]; then


### PR DESCRIPTION
- Set the site name to "testbed.osism.xyz" instead of the default
  "example.com".
- Create a Operatingsystem Group "Ubuntu 20.04" and place the current
  release "Ubuntu 20.04.3 LTS" into it, so that the user doesn't get a
  warning about a missing group after the initial deployment

Closes: osism/issues#53
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>