### PR TITLE
Patch failing host updates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,7 @@ COPY files/local_settings.py /etc/patchman/local_settings.py
 COPY files/requirements.txt /requirements.txt
 COPY files/run.sh /run.sh
 COPY files/fixtures.json /fixtures.json
+COPY files/pman-upd.patch /pman-upd.patch
 
 # hadolint ignore=DL3018
 RUN apt-get update \
@@ -31,6 +32,9 @@ RUN apt-get update \
 
 RUN if [ $VERSION = "latest" ]; then git clone https://github.com/furlongm/patchman.git /repository; fi \
     && if [ $VERSION != "latest" ]; then git clone -b v$VERSION https://github.com/furlongm/patchman.git /repository; fi
+
+# TODO(osfrickler): Drop patch once it has been merged upstream
+RUN patch -d /repository -p1 -i /pman-upd.patch
 
 # hadolint ignore=DL3013
 RUN pip3 install --no-cache-dir --upgrade pip \

--- a/files/pman-upd.patch
+++ b/files/pman-upd.patch
@@ -1,0 +1,14 @@
+diff --git a/sbin/patchman b/sbin/patchman
+index ef69ad6..da96c95 100755
+--- a/sbin/patchman
++++ b/sbin/patchman
+@@ -311,8 +311,7 @@ def host_updates_alt(host=None):
+                 phosts.append(fhost)
+ 
+             for phost in phosts:
+-                phost.updates.clear()
+-                phost.updates = updates
++                phost.updates.set(updates)
+                 phost.updated_at = ts
+                 phost.save()
+                 updated_hosts.append(phost)


### PR DESCRIPTION
Alternative host updates are sometime failing with a TypeError, fix it
by using set() instead of direct assignment.

Closes: osism/testbed#929
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>